### PR TITLE
Fix to allow running user's custom reports identified in user configuration config-user.scm with gnucash-cli

### DIFF
--- a/gnucash/report/gnc-report.c
+++ b/gnucash/report/gnc-report.c
@@ -91,6 +91,15 @@ load_custom_reports_stylesheets(void)
     if (is_user_config_loaded)
         return;
     else is_user_config_loaded = TRUE;
+ 
+    update_message("loading user configuration");
+    {
+        gchar *config_filename;
+        config_filename = g_build_filename (gnc_userconfig_dir (),
+                                                "config-user.scm", (char *)NULL);
+        gfec_try_load(config_filename);
+        g_free(config_filename);
+    }
 
     update_message("loading saved reports");
     try_load_config_array(saved_report_files);


### PR DESCRIPTION
If a user has created custom reports and has added them to the config-user.scf user configuration file as documented in the Custom Report wiki, they work as expected using the GnuCash GUI.  However, when attempting to run the same custom reports using the command line version, gnucash-cli, errors are presented.

The root cause of the error is that the report definitions are not being loaded from the user configuration file, so gnucash-cli cannot find them.  This fix leverages the logic from gnucash-core-app.cpp and applies it in the equivalent point in gnc-report.c which is utilized by gnucash-cli.